### PR TITLE
Require meshzoo 0.9.11 instead of (missing?) 0.10.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - opencv-python==4.5.2.54
     - numpy==1.22.3
     - matplotlib==3.4.3
-    - meshzoo==0.10.2
+    - meshzoo==0.9.11
     - pillow==8.1.0 
     - scikit-image==0.18.1
     - tensorboard==2.2.0


### PR DESCRIPTION
see issue #1 